### PR TITLE
REST API method getTokens limit argument added

### DIFF
--- a/src/main/java/com/binance/dex/api/client/BinanceDexApi.java
+++ b/src/main/java/com/binance/dex/api/client/BinanceDexApi.java
@@ -33,7 +33,7 @@ public interface BinanceDexApi {
     Call<TransactionMetadata> getTransactionMetadata(@Path("hash") String hash);
 
     @GET("/api/v1/tokens")
-    Call<List<Token>> getTokens();
+    Call<List<Token>> getTokens(@Query("limit") Integer limit);
 
     @GET("/api/v1/markets")
     Call<List<Market>> getMarkets(@Query("limit") Integer limit);

--- a/src/main/java/com/binance/dex/api/client/BinanceDexApiAsyncRestClient.java
+++ b/src/main/java/com/binance/dex/api/client/BinanceDexApiAsyncRestClient.java
@@ -25,7 +25,7 @@ public interface BinanceDexApiAsyncRestClient {
 
     void getTransactionMetadata(String hash, BinanceDexApiCallback<TransactionMetadata> callback);
 
-    void getTokens(BinanceDexApiCallback<List<Token>> callback);
+    void getTokens(Integer limit, BinanceDexApiCallback<List<Token>> callback);
 
     void getOrderBook(String symbol, Integer limit, BinanceDexApiCallback<OrderBook> callback);
 

--- a/src/main/java/com/binance/dex/api/client/BinanceDexApiRestClient.java
+++ b/src/main/java/com/binance/dex/api/client/BinanceDexApiRestClient.java
@@ -30,7 +30,7 @@ public interface BinanceDexApiRestClient {
 
     TransactionMetadata getTransactionMetadata(String hash);
 
-    List<Token> getTokens();
+    List<Token> getTokens(Integer limit);
 
     OrderBook getOrderBook(String symbol, Integer limit);
 

--- a/src/main/java/com/binance/dex/api/client/impl/BinanceDexApiAsyncRestClientImpl.java
+++ b/src/main/java/com/binance/dex/api/client/impl/BinanceDexApiAsyncRestClientImpl.java
@@ -58,8 +58,8 @@ public class BinanceDexApiAsyncRestClientImpl implements BinanceDexApiAsyncRestC
     }
 
     @Override
-    public void getTokens(BinanceDexApiCallback<List<Token>> callback) {
-        binanceDexApi.getTokens().enqueue(new BinanceDexApiCallbackAdapter<>(callback));
+    public void getTokens(Integer limit, BinanceDexApiCallback<List<Token>> callback) {
+        binanceDexApi.getTokens(limit).enqueue(new BinanceDexApiCallbackAdapter<>(callback));
     }
 
     @Override

--- a/src/main/java/com/binance/dex/api/client/impl/BinanceDexApiRestClientImpl.java
+++ b/src/main/java/com/binance/dex/api/client/impl/BinanceDexApiRestClientImpl.java
@@ -62,8 +62,8 @@ public class BinanceDexApiRestClientImpl implements BinanceDexApiRestClient {
         return BinanceDexApiClientGenerator.executeSync(binanceDexApi.getTransactionMetadata(hash));
     }
 
-    public List<Token> getTokens() {
-        return BinanceDexApiClientGenerator.executeSync(binanceDexApi.getTokens());
+    public List<Token> getTokens(Integer limit) {
+        return BinanceDexApiClientGenerator.executeSync(binanceDexApi.getTokens(limit));
     }
 
     public OrderBook getOrderBook(String symbol, Integer limit) {

--- a/src/test/java/com/binance/dex/api/client/encoding/message/TestRestClient.java
+++ b/src/test/java/com/binance/dex/api/client/encoding/message/TestRestClient.java
@@ -56,7 +56,7 @@ public class TestRestClient {
 
     @Test
     public void testGetToken() {
-        List<Token> tokens = client.getTokens();
+        List<Token> tokens = client.getTokens(100);
         System.out.println(tokens);
     }
 


### PR DESCRIPTION
Default number of tokens is 100, so the API does not return all tokens on the testnet.