### PR TITLE
Add ability to decode raw signed transactions that are not in blockchain

### DIFF
--- a/src/main/java/com/binance/dex/api/client/TransactionConverter.java
+++ b/src/main/java/com/binance/dex/api/client/TransactionConverter.java
@@ -30,6 +30,7 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional
 import java.util.stream.Collectors;
 
 public class TransactionConverter {
@@ -57,11 +58,11 @@ public class TransactionConverter {
                         }
                         transaction.setHash(txMessage.getHash());
                         transaction.setHeight(txMessage.getHeight());
-                        transaction.setCode(txMessage.getTx_result().getCode());
-                        transaction.setLog(txMessage.getTx_result().getLog());
-                        transaction.setTags(txMessage.getTx_result().getTags());
+                        transaction.setCode(Optional.ofNullable(txMessage.getTx_result()).map(TxResult::getCode).orElse(null));
+                        transaction.setLog(Optional.ofNullable(txMessage.getTx_result()).map(TxResult::getLog).orElse(null));
+                        transaction.setTags(Optional.ofNullable(txMessage.getTx_result()).map(TxResult::getTags).orElse(null));
                         transaction.setMemo(stdTx.getMemo());
-                        transaction.setResultData(txMessage.getTx_result().getData());
+                        transaction.setResultData(Optional.ofNullable(txMessage.getTx_result()).map(TxResult::getData).orElse(null));
                         transaction.setSource(stdTx.getSource());
                         transaction.setSequence(stdSignature.getSequence());
                         return transaction;


### PR DESCRIPTION
When try to decode raw transaction that has no tx_result, decoder fails with null pointer exception. This fix will allow to decode these transactions