### PR TITLE
add pending_match in depth response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 ## 1.0.7
 CHAIN UPGRADE
-* [\#110](https://github.com/binance-chain/java-sdk/pull/84) [RPC] [API] Add Pending match flag to Depth API response
-* [\#115](https://github.com/binance-chain/java-sdk/pull/80) [RPC] [API] Support Mini Token
+* [\#86](https://github.com/binance-chain/java-sdk/pull/86) [RPC] [API] Add Pending match flag to Depth API response
+* [\#80](https://github.com/binance-chain/java-sdk/pull/80) [RPC] [API] Support Mini Token

--- a/src/main/java/com/binance/dex/api/client/domain/OrderBook.java
+++ b/src/main/java/com/binance/dex/api/client/domain/OrderBook.java
@@ -2,15 +2,20 @@ package com.binance.dex.api.client.domain;
 
 import com.binance.dex.api.client.BinanceDexConstants;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class OrderBook {
     private List<OrderBookEntry> asks;
     private List<OrderBookEntry> bids;
     private long height;
+    @JsonProperty("pending_match")
+    private Boolean pendingMatch;
 
     public List<OrderBookEntry> getAsks() {
         return asks;
@@ -36,12 +41,22 @@ public class OrderBook {
         this.height = height;
     }
 
+    public boolean isPendingMatch() {
+        return pendingMatch;
+    }
+
+    public void setPendingMatch(boolean pendingMatch) {
+        this.pendingMatch = pendingMatch;
+    }
+
     @Override
     public String toString() {
         return new ToStringBuilder(this, BinanceDexConstants.BINANCE_DEX_TO_STRING_STYLE)
                 .append("asks", asks)
                 .append("bids", bids)
                 .append("height", height)
+                .append("pendingMatch", pendingMatch)
                 .toString();
     }
+
 }


### PR DESCRIPTION
Depth rest API change and orderbook rpc API change: add a new flag pending_match.

The pending_match flag in the response is to indicate below orderbook status: there are new orders created in current block, but the matching process has not started for the block, then pending_math=true. As a result, there could be orders with cross prices - price of ask is lower than price of bid. Client can ignore the response with pending_match=true and query the depth API until pending_match=false.