### PR TITLE
Release/v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.1.2
+API UPGRADE
+* [\#118](https://github.com/binance-chain/java-sdk/pull/118) [RPC] [API] deco old rest transactions api, and add new rest transaction apis
+
+Breaking Changes
+* getTransactions(TransactionsRequest request) will return transactions with new data model TransactionPageV2
+* getTransactions(String address) will return transactions for an address in last 24 hours with new data model TransactionPageV2
+
+Please refer to TransactionConverterFactory.java to see the mappings of the fields between TransactionPageV2 and TransactionPage 
+
+Please refer to TransactionExample.java and [API Doc](https://docs.binance.org/api-reference/dex-api/block-service.html) for more details
+
+New API
+* getTransactionsInBlock(long blockHeight) will return transaction in a specific block. 
+
+
 ## 1.1.1
 CHAIN UPGRADE
 * [\#105](https://github.com/binance-chain/java-sdk/pull/105) [RPC] [API] support for the transfer of token ownership, and decode the new types of oracle claim package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.2
 API UPGRADE
-* [\#118](https://github.com/binance-chain/java-sdk/pull/118) [RPC] [API] deco old rest transactions api, and add new rest transaction apis
+* [\#120](https://github.com/binance-chain/java-sdk/pull/120) [RPC] [API] deco old rest transactions api, and add new rest transaction apis
 
 Breaking Changes
 * getTransactions(TransactionsRequest request) will return transactions with new data model TransactionPageV2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Breaking Changes
 
 Please refer to TransactionConverterFactory.java to see the mappings of the fields between TransactionPageV2 and TransactionPage 
 
-Please refer to TransactionExample.java and [API Doc](https://docs.binance.org/api-reference/dex-api/block-service.html) for more details
+Please refer to TransactionExample.java and [API Doc](https://docs.binance.org/api-reference/dex-api/block-service.html) for more details, the underlying API [Migration Guide](https://github.com/binance-chain/docs-site/blob/block-service/docs/api-reference/dex-api/migration-guide.md) could be also useful 
 
 New API
 * getTransactionsInBlock(long blockHeight) will return transaction in a specific block. 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Binance Chain Java SDK works as a lightweight Java library for interacting w
 <dependency>
     <groupId>com.binance.dex.api</groupId>
     <artifactId>binance-dex-api-client</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.2</version>
 </dependency>
 ```
 # Protobuf

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.binance.dex.api</groupId>
     <artifactId>binance-dex-api-client</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
 
     <properties>
         <com.squareup.retrofit2.version>2.6.0</com.squareup.retrofit2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.binance.dex.api</groupId>
     <artifactId>binance-dex-api-client</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
 
     <properties>
         <com.squareup.retrofit2.version>2.6.0</com.squareup.retrofit2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.binance.dex.api</groupId>
     <artifactId>binance-dex-api-client</artifactId>
-    <version>1.1.3</version>
+    <version>1.1.2</version>
 
     <properties>
         <com.squareup.retrofit2.version>2.6.0</com.squareup.retrofit2.version>

--- a/src/main/java/com/binance/dex/api/client/BinanceDexApi.java
+++ b/src/main/java/com/binance/dex/api/client/BinanceDexApi.java
@@ -76,13 +76,6 @@ public interface BinanceDexApi {
                               @Query("sellerOrderId") String sellerOrderId, @Query("side") Integer side,
                               @Query("start") Long start, @Query("symbol") String symbol, @Query("total") Integer total);
 
-    @GET("api/v1/transactions")
-    Call<TransactionPage> getTransactions(@Query("address") String address, @Query("blockHeight") Long blockHeight,
-                                          @Query("endTime") Long endTime, @Query("limit") Integer limit,
-                                          @Query("offset") Integer offset, @Query("side") String side,
-                                          @Query("startTime") Long startTime, @Query("txAsset") String txAsset,
-                                          @Query("txType") String txType);
-
     @POST("api/v1/broadcast")
     Call<List<TransactionMetadata>> broadcast(@Query("sync") boolean sync, @Body RequestBody transaction);
 

--- a/src/main/java/com/binance/dex/api/client/BinanceDexApiAsyncRestClient.java
+++ b/src/main/java/com/binance/dex/api/client/BinanceDexApiAsyncRestClient.java
@@ -51,9 +51,11 @@ public interface BinanceDexApiAsyncRestClient {
 
     void getTrades(TradesRequest request, BinanceDexApiCallback<TradePage> callback);
 
-    void getTransactions(String address, BinanceDexApiCallback<TransactionPage> callback);
+    void getTransactions(String address, BinanceDexApiCallback<TransactionPageV2> callback);
 
-    void getTransactions(TransactionsRequest request, BinanceDexApiCallback<TransactionPage> callback);
+    void getTransactions(TransactionsRequest request, BinanceDexApiCallback<TransactionPageV2> callback);
+
+    void getTransactionsInBlock(long blockHeight, BinanceDexApiCallback<TransactionPageV2> callback);
 
     // Do not support async commitBroadcast due to account sequence
 }

--- a/src/main/java/com/binance/dex/api/client/BinanceDexApiNodeClient.java
+++ b/src/main/java/com/binance/dex/api/client/BinanceDexApiNodeClient.java
@@ -132,12 +132,17 @@ public interface BinanceDexApiNodeClient extends BinanceDexApiRestClient {
     }
 
     @Override
-    default TransactionPage getTransactions(String address) {
+    default TransactionPageV2 getTransactions(String address) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    default TransactionPage getTransactions(TransactionsRequest request) {
+    default TransactionPageV2 getTransactions(TransactionsRequest request) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    default TransactionPageV2 getTransactionsInBlock(long blockHeight) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/com/binance/dex/api/client/BinanceDexApiRestClient.java
+++ b/src/main/java/com/binance/dex/api/client/BinanceDexApiRestClient.java
@@ -56,9 +56,11 @@ public interface BinanceDexApiRestClient {
 
     TradePage getTrades(TradesRequest request);
 
-    TransactionPage getTransactions(String address);
+    TransactionPageV2 getTransactions(String address);
 
-    TransactionPage getTransactions(TransactionsRequest request);
+    TransactionPageV2 getTransactions(TransactionsRequest request);
+
+    TransactionPageV2 getTransactionsInBlock(long blockHeight);
 
     List<MiniToken> getMiniTokens(Integer limit);
 

--- a/src/main/java/com/binance/dex/api/client/BinanceDexEnvironment.java
+++ b/src/main/java/com/binance/dex/api/client/BinanceDexEnvironment.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 public class BinanceDexEnvironment {
     public static final BinanceDexEnvironment PROD = new BinanceDexEnvironment(
             "https://dex.binance.org",
+            "https://api.binance.org/bc/",
             "wss://dex.binance.org/api",
             "https://dataseed1.ninicoin.io",
             "wss://dataseed1.ninicoin.io/websocket",
@@ -14,6 +15,7 @@ public class BinanceDexEnvironment {
     );
     public static final BinanceDexEnvironment TEST_NET = new BinanceDexEnvironment(
             "https://testnet-dex.binance.org",
+            "https://testnet-api.binance.org/bc/",
             "wss://testnet-dex.binance.org/api",
             "http://data-seed-pre-0-s3.binance.org",
             "wss://data-seed-pre-0-s3.binance.org/websocket",
@@ -23,6 +25,8 @@ public class BinanceDexEnvironment {
 
     // Rest API base URL
     private String baseUrl;
+    // Chain transaction API base URL
+    private String transactionUrl;
     // Websocket data stream url
     private String streamUrl;
     // RPC API base URL
@@ -41,10 +45,25 @@ public class BinanceDexEnvironment {
         this.wsBaseUrl = wsBaseUrl;
         this.hrp = hrp;
         this.valHrp = valHrp;
+        this.transactionUrl = inferTransactionUrl(baseUrl);
+    }
+
+    public BinanceDexEnvironment(String baseUrl, String transactionUrl, String streamUrl, String nodeUrl, String wsBaseUrl, String hrp, String valHrp) {
+        this.baseUrl = baseUrl;
+        this.transactionUrl = transactionUrl;
+        this.streamUrl = streamUrl;
+        this.nodeUrl = nodeUrl;
+        this.wsBaseUrl = wsBaseUrl;
+        this.hrp = hrp;
+        this.valHrp = valHrp;
     }
 
     public String getBaseUrl() {
         return baseUrl;
+    }
+
+    public String getTransactionUrl() {
+        return transactionUrl;
     }
 
     public String getStreamUrl() {
@@ -61,6 +80,16 @@ public class BinanceDexEnvironment {
 
     public String getValHrp() {
         return valHrp;
+    }
+
+    public static String inferTransactionUrl(String baseUrl) {
+        String transactionUrl = null;
+        if (baseUrl != null && baseUrl.equalsIgnoreCase(BinanceDexEnvironment.PROD.baseUrl)) {
+            transactionUrl = BinanceDexEnvironment.PROD.transactionUrl;
+        } else if (baseUrl != null && baseUrl.equalsIgnoreCase(BinanceDexEnvironment.TEST_NET.baseUrl)) {
+            transactionUrl = BinanceDexEnvironment.TEST_NET.transactionUrl;
+        }
+        return transactionUrl;
     }
 
     @Override

--- a/src/main/java/com/binance/dex/api/client/BinanceTransactionApi.java
+++ b/src/main/java/com/binance/dex/api/client/BinanceTransactionApi.java
@@ -1,0 +1,22 @@
+package com.binance.dex.api.client;
+
+import com.binance.dex.api.client.domain.TransactionPageV2;
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+public interface BinanceTransactionApi {
+    @GET("api/v1/txs")
+    Call<TransactionPageV2> getTransactions(@Query(value = "startTime") Long startTime,
+                                            @Query(value = "endTime") Long endTime,
+                                            @Query(value = "type") String type,
+                                            @Query(value = "asset") String asset,
+                                            @Query(value = "address") String address,
+                                            @Query(value = "addressType") String addressType,
+                                            @Query(value = "offset") Integer offset,
+                                            @Query(value = "limit") Integer limit);
+
+    @GET("api/v1/blocks/{blockHeight}/txs")
+    Call<TransactionPageV2> getTransactionsInBlock(@Path("blockHeight") long blockHeight);
+}

--- a/src/main/java/com/binance/dex/api/client/domain/TransactionPageV2.java
+++ b/src/main/java/com/binance/dex/api/client/domain/TransactionPageV2.java
@@ -1,0 +1,37 @@
+package com.binance.dex.api.client.domain;
+
+import com.binance.dex.api.client.BinanceDexConstants;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TransactionPageV2 {
+    private Long total;
+    private List<TransactionV2> txs;
+
+    public Long getTotal() {
+        return total;
+    }
+
+    public void setTotal(Long total) {
+        this.total = total;
+    }
+
+    public List<TransactionV2> getTxs() {
+        return txs;
+    }
+
+    public void setTxs(List<TransactionV2> txs) {
+        this.txs = txs;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, BinanceDexConstants.BINANCE_DEX_TO_STRING_STYLE)
+                .append("total", total)
+                .append("txs", txs)
+                .toString();
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/domain/TransactionV2.java
+++ b/src/main/java/com/binance/dex/api/client/domain/TransactionV2.java
@@ -1,0 +1,166 @@
+package com.binance.dex.api.client.domain;
+
+import com.binance.dex.api.client.BinanceDexConstants;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TransactionV2 {
+    private String hash;
+    private long blockHeight;
+    private long blockTime;
+    private String type;
+    private Long fee;
+    private int code;
+    private long source;
+    private long sequence;
+    private String memo;
+    private String log;
+    private String data;
+
+    private String asset;
+    private Long amount;
+
+    private String fromAddr;
+    private String toAddr;
+
+    public String getHash() {
+        return hash;
+    }
+
+    public void setHash(String hash) {
+        this.hash = hash;
+    }
+
+    public long getBlockHeight() {
+        return blockHeight;
+    }
+
+    public void setBlockHeight(long blockHeight) {
+        this.blockHeight = blockHeight;
+    }
+
+    public long getBlockTime() {
+        return blockTime;
+    }
+
+    public void setBlockTime(long blockTime) {
+        this.blockTime = blockTime;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Long getFee() {
+        return fee;
+    }
+
+    public void setFee(Long fee) {
+        this.fee = fee;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public void setCode(int code) {
+        this.code = code;
+    }
+
+    public long getSource() {
+        return source;
+    }
+
+    public void setSource(long source) {
+        this.source = source;
+    }
+
+    public long getSequence() {
+        return sequence;
+    }
+
+    public void setSequence(long sequence) {
+        this.sequence = sequence;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
+    public void setMemo(String memo) {
+        this.memo = memo;
+    }
+
+    public String getLog() {
+        return log;
+    }
+
+    public void setLog(String log) {
+        this.log = log;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+
+    public String getAsset() {
+        return asset;
+    }
+
+    public void setAsset(String asset) {
+        this.asset = asset;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Long amount) {
+        this.amount = amount;
+    }
+
+    public String getFromAddr() {
+        return fromAddr;
+    }
+
+    public void setFromAddr(String fromAddr) {
+        this.fromAddr = fromAddr;
+    }
+
+    public String getToAddr() {
+        return toAddr;
+    }
+
+    public void setToAddr(String toAddr) {
+        this.toAddr = toAddr;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, BinanceDexConstants.BINANCE_DEX_TO_STRING_STYLE)
+                .append("blockHeight", blockHeight)
+                .append("code", code)
+                .append("data", data)
+                .append("fromAddr", fromAddr)
+                .append("blockTime", blockTime)
+                .append("toAddr", toAddr)
+                .append("asset", asset)
+                .append("fee", fee)
+                .append("hash", hash)
+                .append("type", type)
+                .append("amount", amount)
+                .append("memo", memo)
+                .append("sequence", sequence)
+                .append("log", log)
+                .toString();
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/domain/request/TransactionsRequest.java
+++ b/src/main/java/com/binance/dex/api/client/domain/request/TransactionsRequest.java
@@ -6,30 +6,21 @@ import com.binance.dex.api.client.domain.TransactionType;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 public class TransactionsRequest {
-    private String address;
-    private Long blockHeight;
-    private Long endTime;
-    private Integer limit;
-    private Integer offset;
-    private OrderSide side;
     private Long startTime;
-    private String txAsset;
-    private TransactionType txType;
+    private Long endTime;
+    private String type;
+    private String asset;
+    private String address;
+    private String addressType;
+    private Integer offset;
+    private  Integer limit;
 
-    public String getAddress() {
-        return address;
+    public Long getStartTime() {
+        return startTime;
     }
 
-    public void setAddress(String address) {
-        this.address = address;
-    }
-
-    public Long getBlockHeight() {
-        return blockHeight;
-    }
-
-    public void setBlockHeight(Long blockHeight) {
-        this.blockHeight = blockHeight;
+    public void setStartTime(Long startTime) {
+        this.startTime = startTime;
     }
 
     public Long getEndTime() {
@@ -40,12 +31,36 @@ public class TransactionsRequest {
         this.endTime = endTime;
     }
 
-    public Integer getLimit() {
-        return limit;
+    public String getType() {
+        return type;
     }
 
-    public void setLimit(Integer limit) {
-        this.limit = limit;
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getAsset() {
+        return asset;
+    }
+
+    public void setAsset(String asset) {
+        this.asset = asset;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getAddressType() {
+        return addressType;
+    }
+
+    public void setAddressType(String addressType) {
+        this.addressType = addressType;
     }
 
     public Integer getOffset() {
@@ -56,50 +71,25 @@ public class TransactionsRequest {
         this.offset = offset;
     }
 
-    public OrderSide getSide() {
-        return side;
+    public Integer getLimit() {
+        return limit;
     }
 
-    public void setSide(OrderSide side) {
-        this.side = side;
-    }
-
-    public Long getStartTime() {
-        return startTime;
-    }
-
-    public void setStartTime(Long startTime) {
-        this.startTime = startTime;
-    }
-
-    public String getTxAsset() {
-        return txAsset;
-    }
-
-    public void setTxAsset(String txAsset) {
-        this.txAsset = txAsset;
-    }
-
-    public TransactionType getTxType() {
-        return txType;
-    }
-
-    public void setTxType(TransactionType txType) {
-        this.txType = txType;
+    public void setLimit(Integer limit) {
+        this.limit = limit;
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this, BinanceDexConstants.BINANCE_DEX_TO_STRING_STYLE)
-                .append("address", address)
-                .append("blockHeight", blockHeight)
+                .append("startTime", startTime)
                 .append("endTime", endTime)
+                .append("type", type)
+                .append("asset", asset)
+                .append("address", address)
+                .append("addressType", addressType)
                 .append("limit", limit)
                 .append("offset", offset)
-                .append("side", side)
-                .append("startTime", startTime)
-                .append("txAsset", txAsset)
-                .append("txType", txType)
                 .toString();
     }
 }

--- a/src/main/java/com/binance/dex/api/client/utils/converter/DateUtil.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/DateUtil.java
@@ -1,0 +1,102 @@
+package com.binance.dex.api.client.utils.converter;
+
+import java.text.SimpleDateFormat;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
+public class DateUtil {
+
+    private static final DateTimeFormatter utcFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneId.of("UTC"));
+
+    public static long betweenSecs(Date date1, Date date2) {
+        return Duration.between(date1.toInstant(), date2.toInstant()).getSeconds();
+    }
+
+    public static long betweenDays(Date date1, Date date2) {
+        return date1.toInstant().until(date2.toInstant(), ChronoUnit.DAYS);
+    }
+
+    public static boolean isSameDay(Date date1, Date date2) {
+        Calendar cal1 = Calendar.getInstance();
+        Calendar cal2 = Calendar.getInstance();
+        cal1.setTime(date1);
+        cal2.setTime(date2);
+        return cal1.get(Calendar.DAY_OF_YEAR) == cal2.get(Calendar.DAY_OF_YEAR) &&
+                cal1.get(Calendar.YEAR) == cal2.get(Calendar.YEAR);
+    }
+
+    public static Date toDateFromMilliseconds(Long time) {
+        if (null == time) {
+            return null;
+        }
+        return Date.from(Instant.ofEpochMilli(time));
+    }
+
+    public static Date now() {
+        return Date.from(Instant.now());
+    }
+
+    public static Date parseUTCMilliTime(String dateStr) {
+        ZonedDateTime zdt = ZonedDateTime.parse(dateStr, utcFormatter);
+        return Date.from(zdt.toInstant());
+    }
+
+    public static Date parseUTCTime(String dateStr) {
+        return Date.from(Instant.parse(dateStr));
+    }
+
+    /**
+     * Formats a date at any given format String, at any given Timezone String.
+     *
+     * @param date     Valid Date object
+     * @param format   String representation of the format, e.g. "yyyy-MM-dd HH:mm"
+     * @param timezone String representation of the time zone, e.g. "CST"
+     * @return The formatted date in the given time zone.
+     */
+    public static String toString(final Date date, final String format, final String timezone) {
+        final TimeZone tz = TimeZone.getTimeZone(timezone);
+        final SimpleDateFormat formatter = new SimpleDateFormat(format);
+        formatter.setTimeZone(tz);
+        return formatter.format(date);
+    }
+
+    private static LocalDateTime dateToUtcDateTime(Date date) {
+        return LocalDateTime.ofInstant(date.toInstant(), ZoneId.of("UTC"));
+    }
+
+    private static Date utcDateTimeToDate(LocalDateTime localDateTime) {
+        return Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+    }
+
+    public static Date getPreviousDate(Date date) {
+        LocalDateTime localDateTime = dateToUtcDateTime(date);
+        LocalDateTime previousDate = localDateTime.minusDays(1l);
+        return utcDateTimeToDate(previousDate);
+    }
+
+    public static String toUTCDateString(final Date date) {
+        return toString(date, "yyyyMMdd", "UTC");
+    }
+
+    public static String toUTCDateString(long timeStamp) {
+        return toString(new Date(timeStamp), "yyyyMMdd", "UTC");
+    }
+
+    public static Date atStartOfDay(Date date) {
+        LocalDateTime localDateTime = dateToUtcDateTime(date);
+        LocalDateTime startOfDay = localDateTime.with(LocalTime.MIN);
+        return utcDateTimeToDate(startOfDay);
+    }
+
+    public static Date atEndOfDay(Date date) {
+        LocalDateTime localDateTime = dateToUtcDateTime(date);
+        LocalDateTime endOfDay = localDateTime.with(LocalTime.MAX);
+        return utcDateTimeToDate(endOfDay);
+    }
+
+
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/JsonUtil.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/JsonUtil.java
@@ -1,0 +1,57 @@
+package com.binance.dex.api.client.utils.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+import java.io.IOException;
+import java.util.List;
+
+public class JsonUtil {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final TypeFactory typeFactory = objectMapper.getTypeFactory();
+
+    static {
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+
+    public static ObjectNode createObjectNode() {
+        return objectMapper.createObjectNode();
+    }
+
+    public static String toJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static <T> T fromJson(String jsonStr, Class<T> tClass) {
+        try {
+            return objectMapper.readValue(jsonStr, tClass);
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static <T> List<T> fromJsonToList(String jsonStr, Class<T> tClass) {
+        try {
+            return objectMapper.readValue(jsonStr, typeFactory.constructCollectionType(List.class, tClass));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    public static JsonNode toJsonNode(String json) throws Exception {
+        return objectMapper.readTree(json);
+    }
+
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/NumberUtil.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/NumberUtil.java
@@ -1,0 +1,42 @@
+package com.binance.dex.api.client.utils.converter;
+
+import java.math.BigDecimal;
+import java.text.DecimalFormat;
+
+public class NumberUtil {
+
+    public static final Integer SHIFT_DIGITS = 8;
+
+    public static BigDecimal longToBigDecimal(Long value) {
+        return longToBigDecimal(value, SHIFT_DIGITS);
+    }
+
+    public static String longToBigDecimalString(Long value) {
+        return decimalFormat(longToBigDecimal(value, SHIFT_DIGITS));
+    }
+
+    public static BigDecimal longToBigDecimal(Long value, Integer shiftDigits) {
+        if (null == value) {
+            return null;
+        }
+        return BigDecimal.valueOf(value).movePointLeft(shiftDigits);
+    }
+
+    public static Long bigDecimalToLong(BigDecimal value) {
+        return bigDecimalToLong(value, SHIFT_DIGITS);
+    }
+
+    private static Long bigDecimalToLong(BigDecimal value, Integer precision) {
+        if (null == value) {
+            return null;
+        }
+        return value.multiply(BigDecimal.TEN.pow(precision)).longValue();
+    }
+
+    public static String decimalFormat(BigDecimal value) {
+        if (value == null) {
+            return null;
+        }
+        return new DecimalFormat("0.00000000").format(value);
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/Token.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/Token.java
@@ -1,0 +1,67 @@
+package com.binance.dex.api.client.utils.converter;
+
+import com.binance.dex.api.client.BinanceDexConstants;
+import com.binance.dex.api.proto.Send;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Builder;
+import lombok.Data;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+@Data
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder(alphabetic = true)
+public class Token {
+    @JsonProperty(value = "denom")
+    private String denom;
+    @JsonProperty(value = "amount")
+    private Long amount;
+
+    public static com.binance.dex.api.client.encoding.message.Token of(com.binance.dex.api.proto.Token source) {
+        com.binance.dex.api.client.encoding.message.Token token = new com.binance.dex.api.client.encoding.message.Token();
+        token.setDenom(source.getDenom());
+        token.setAmount(source.getAmount());
+        return token;
+    }
+
+    public static com.binance.dex.api.client.encoding.message.Token of(Send.Token sendToken) {
+        com.binance.dex.api.client.encoding.message.Token token = new com.binance.dex.api.client.encoding.message.Token();
+        token.setDenom(sendToken.getDenom());
+        token.setAmount(sendToken.getAmount());
+        return token;
+    }
+
+    public Token() {
+    }
+
+    public Token(String denom, Long amount) {
+        this.denom = denom;
+        this.amount = amount;
+    }
+
+    public String getDenom() {
+        return denom;
+    }
+
+    public void setDenom(String denom) {
+        this.denom = denom;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Long amount) {
+        this.amount = amount;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, BinanceDexConstants.BINANCE_DEX_TO_STRING_STYLE)
+                .append("denom", denom)
+                .append("amount", amount)
+                .toString();
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/TransactionConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/TransactionConverter.java
@@ -1,0 +1,27 @@
+package com.binance.dex.api.client.utils.converter;
+
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+
+import java.util.Map;
+
+
+public abstract class TransactionConverter<T> {
+
+    // construct tx data information based on different tx types
+    public abstract void doConvert(TransactionV2 transactionV2, Transaction transaction);
+
+    public abstract com.binance.dex.api.client.domain.broadcast.TxType getType();
+
+    protected Token getToken(Map<String, Object> map, String key) {
+        Map<String, Object> m = (Map<String, Object>) map.get(key);
+        String denom = m.get("denom").toString();
+        Long amount = ((Number) m.get("amount")).longValue();
+        Token token = new Token();
+        token.setDenom(denom);
+        token.setAmount(amount);
+        return token;
+    }
+
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/TransactionConverterFactory.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/TransactionConverterFactory.java
@@ -1,0 +1,193 @@
+package com.binance.dex.api.client.utils.converter;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionPage;
+import com.binance.dex.api.client.domain.TransactionPageV2;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.utils.converter.impl.*;
+import com.google.common.collect.Maps;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Map;
+
+
+public class TransactionConverterFactory {
+
+    private static Map<com.binance.dex.api.client.domain.broadcast.TxType, TransactionConverter> converterMap = Maps.newHashMap();
+
+    static {
+        FBscSubmitEvidenceConverter bscSubmitEvidenceConverter = new FBscSubmitEvidenceConverter();
+        converterMap.put(bscSubmitEvidenceConverter.getType(), bscSubmitEvidenceConverter);
+
+        FBurnConverter burnConverter = new FBurnConverter();
+        converterMap.put(burnConverter.getType(), burnConverter);
+
+        FCancelOrderConverter cancelOrderConverter = new FCancelOrderConverter();
+        converterMap.put(cancelOrderConverter.getType(), cancelOrderConverter);
+
+        FClaimHtlConverter claimHtlConverter = new FClaimHtlConverter();
+        converterMap.put(claimHtlConverter.getType(), claimHtlConverter);
+
+        FCreateSideChainValidatorConverter createSideChainValidatorConverter = new FCreateSideChainValidatorConverter();
+        converterMap.put(createSideChainValidatorConverter.getType(), createSideChainValidatorConverter);
+
+        FCreateValidatorConverter createValidatorConverter = new FCreateValidatorConverter();
+        converterMap.put(createValidatorConverter.getType(), createValidatorConverter);
+
+        FCrossBindConverter crossBindConverter = new FCrossBindConverter();
+        converterMap.put(crossBindConverter.getType(), crossBindConverter);
+
+        FCrossTransferOutConverter crossTransferOutConverter = new FCrossTransferOutConverter();
+        converterMap.put(crossTransferOutConverter.getType(), crossTransferOutConverter);
+
+        FCrossUnBindConverter crossUnBindConverter = new FCrossUnBindConverter();
+        converterMap.put(crossUnBindConverter.getType(), crossUnBindConverter);
+
+        FDepositConverter depositConverter = new FDepositConverter();
+        converterMap.put(depositConverter.getType(), depositConverter);
+
+        FDepositHtlConverter depositHtlConverter = new FDepositHtlConverter();
+        converterMap.put(depositHtlConverter.getType(), depositHtlConverter);
+
+        FEditSideChainValidatorConverter editSideChainValidatorConverter = new FEditSideChainValidatorConverter();
+        converterMap.put(editSideChainValidatorConverter.getType(), editSideChainValidatorConverter);
+
+        FFreezeConverter freezeConverter = new FFreezeConverter();
+        converterMap.put(freezeConverter.getType(), freezeConverter);
+
+        FHtlTransferConverter htlTransferConverter = new FHtlTransferConverter();
+        converterMap.put(htlTransferConverter.getType(), htlTransferConverter);
+
+        FIssueTokenConverter issueTokenConverter = new FIssueTokenConverter();
+        converterMap.put(issueTokenConverter.getType(), issueTokenConverter);
+
+        FListingConverter listingConverter = new FListingConverter();
+        converterMap.put(listingConverter.getType(), listingConverter);
+
+        FMiniTokenIssueConverter miniTokenIssueConverter = new FMiniTokenIssueConverter();
+        converterMap.put(miniTokenIssueConverter.getType(), miniTokenIssueConverter);
+
+        FMiniTokenListingConverter miniTokenListingConverter = new FMiniTokenListingConverter();
+        converterMap.put(miniTokenListingConverter.getType(), miniTokenListingConverter);
+
+        FMiniTokenSetURIConverter miniTokenSetURIConverter = new FMiniTokenSetURIConverter();
+        converterMap.put(miniTokenSetURIConverter.getType(), miniTokenSetURIConverter);
+
+        FMintConverter mintConverter = new FMintConverter();
+        converterMap.put(mintConverter.getType(), mintConverter);
+
+        FNewOrderConverter newOrderConverter = new FNewOrderConverter();
+        converterMap.put(newOrderConverter.getType(), newOrderConverter);
+
+        FOracleClaimConverter oracleClaimConverter = new FOracleClaimConverter();
+        converterMap.put(oracleClaimConverter.getType(), oracleClaimConverter);
+
+        FProposalConverter proposalConverter = new FProposalConverter();
+        converterMap.put(proposalConverter.getType(), proposalConverter);
+
+        FRefundHtlConverter refundHtlConverter = new FRefundHtlConverter();
+        converterMap.put(refundHtlConverter.getType(), refundHtlConverter);
+
+        FRemoveValidatorConverter removeValidatorConverter = new FRemoveValidatorConverter();
+        converterMap.put(removeValidatorConverter.getType(), removeValidatorConverter);
+
+        FSetAccountFlagsConverter setAccountFlagsConverter = new FSetAccountFlagsConverter();
+        converterMap.put(setAccountFlagsConverter.getType(), setAccountFlagsConverter);
+
+        FSideChainDelegateConverter sideChainDelegateConverter = new FSideChainDelegateConverter();
+        converterMap.put(sideChainDelegateConverter.getType(), sideChainDelegateConverter);
+
+        FSideChainRedelegateConverter sideChainRedelegateConverter = new FSideChainRedelegateConverter();
+        converterMap.put(sideChainRedelegateConverter.getType(), sideChainRedelegateConverter);
+
+        FSideChainUnJailConverter sideChainUnJailConverter = new FSideChainUnJailConverter();
+        converterMap.put(sideChainUnJailConverter.getType(), sideChainUnJailConverter);
+
+        FSideChainUndelegateConverter sideChainUndelegateConverter = new FSideChainUndelegateConverter();
+        converterMap.put(sideChainUndelegateConverter.getType(), sideChainUndelegateConverter);
+
+        FSideDepositConverter sideDepositConverter = new FSideDepositConverter();
+        converterMap.put(sideDepositConverter.getType(), sideDepositConverter);
+
+        FSideProposalConverter sideProposalConverter = new FSideProposalConverter();
+        converterMap.put(sideProposalConverter.getType(), sideProposalConverter);
+
+        FSideVoteConverter sideVoteConverter = new FSideVoteConverter();
+        converterMap.put(sideVoteConverter.getType(), sideVoteConverter);
+
+        FTimeLockConverter timeLockConverter = new FTimeLockConverter();
+        converterMap.put(timeLockConverter.getType(), timeLockConverter);
+
+        FTimeReLockConverter timeReLockConverter = new FTimeReLockConverter();
+        converterMap.put(timeReLockConverter.getType(), timeReLockConverter);
+
+        FTimeUnlockConverter timeUnlockConverter = new FTimeUnlockConverter();
+        converterMap.put(timeUnlockConverter.getType(), timeUnlockConverter);
+
+        FTinyTokenIssueConverter tinyTokenIssueConverter = new FTinyTokenIssueConverter();
+        converterMap.put(tinyTokenIssueConverter.getType(), tinyTokenIssueConverter);
+
+        FTransferConverter transferConverter = new FTransferConverter();
+        converterMap.put(transferConverter.getType(), transferConverter);
+
+        FTransferOwnershipConverter transferOwnershipConverter = new FTransferOwnershipConverter();
+        converterMap.put(transferOwnershipConverter.getType(), transferOwnershipConverter);
+
+        FUnfreezeConverter unfreezeConverter = new FUnfreezeConverter();
+        converterMap.put(unfreezeConverter.getType(), unfreezeConverter);
+
+        FVoteConverter voteConverter = new FVoteConverter();
+        converterMap.put(voteConverter.getType(), voteConverter);
+    }
+
+    public static <T extends TransactionConverter> T getConverter(com.binance.dex.api.client.domain.broadcast.TxType txType) {
+        if (converterMap.containsKey(txType)) {
+            return (T) converterMap.get(txType);
+        }
+        return null;
+    }
+
+
+    public Transaction convert(TransactionV2 transactionV2) {
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        if (transactionV2 == null) {
+            return null;
+        }
+        Transaction transaction = new Transaction();
+        transaction.setBlockHeight(transactionV2.getBlockHeight());
+        transaction.setTxHash(transactionV2.getHash());
+        transaction.setTxType(transactionV2.getType());
+        transaction.setTimeStamp(formatter.format(new Date(transactionV2.getBlockTime())));
+
+
+        transaction.setCode(transactionV2.getCode());
+        transaction.setMemo(transactionV2.getMemo());
+
+        transaction.setTxAsset(transactionV2.getAsset());
+        transaction.setFromAddr(transactionV2.getFromAddr());
+        transaction.setData(transactionV2.getData());
+
+        transaction.setTxAge(DateUtil.betweenSecs(new Date(transactionV2.getBlockTime()), DateUtil.now()));
+
+        transaction.setTxFee(NumberUtil.longToBigDecimalString(transactionV2.getFee()));
+
+        TransactionConverter converter = getConverter(TxType.getTypeByName(transactionV2.getType()));
+        converter.doConvert(transactionV2, transaction);
+
+        return transaction;
+    }
+
+    public TransactionPage convert(TransactionPageV2 transactionPageV2) {
+        TransactionPage transactionPage = new TransactionPage();
+        if (transactionPageV2 != null) {
+            transactionPage.setTotal(transactionPageV2.getTotal());
+            transactionPage.setTx(new ArrayList<>());
+            transactionPageV2.getTxs().stream().forEach(tx -> {
+                transactionPage.getTx().add(convert(tx));
+            });
+        }
+        return transactionPage;
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/TransactionConverterFactory.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/TransactionConverterFactory.java
@@ -160,7 +160,7 @@ public class TransactionConverterFactory {
         transaction.setTxHash(transactionV2.getHash());
         transaction.setTxType(transactionV2.getType());
         transaction.setTimeStamp(formatter.format(new Date(transactionV2.getBlockTime())));
-
+        transaction.setConfirmBlocks(0L);
 
         transaction.setCode(transactionV2.getCode());
         transaction.setMemo(transactionV2.getMemo());

--- a/src/main/java/com/binance/dex/api/client/utils/converter/TxType.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/TxType.java
@@ -1,0 +1,69 @@
+package com.binance.dex.api.client.utils.converter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum TxType {
+    NEW_ORDER(com.binance.dex.api.client.domain.broadcast.TxType.NEW_ORDER),
+    ISSUE_TOKEN(com.binance.dex.api.client.domain.broadcast.TxType.ISSUE),
+    BURN_TOKEN(com.binance.dex.api.client.domain.broadcast.TxType.BURN),
+    LIST_TOKEN(com.binance.dex.api.client.domain.broadcast.TxType.LISTING),
+    CANCEL_ORDER(com.binance.dex.api.client.domain.broadcast.TxType.CANCEL_ORDER),
+    FREEZE_TOKEN(com.binance.dex.api.client.domain.broadcast.TxType.FREEZE_TOKEN),
+    UN_FREEZE_TOKEN(com.binance.dex.api.client.domain.broadcast.TxType.UNFREEZE_TOKEN),
+    TRANSFER(com.binance.dex.api.client.domain.broadcast.TxType.TRANSFER),
+    PROPOSAL(com.binance.dex.api.client.domain.broadcast.TxType.SUBMIT_PROPOSAL),
+    SIDE_PROPOSAL(com.binance.dex.api.client.domain.broadcast.TxType.SIDE_SUBMIT_PROPOSAL),
+    VOTE(com.binance.dex.api.client.domain.broadcast.TxType.VOTE),
+    SIDE_VOTE(com.binance.dex.api.client.domain.broadcast.TxType.SIDE_VOTE),
+    DEPOSIT(com.binance.dex.api.client.domain.broadcast.TxType.DEPOSIT),
+    SIDE_DEPOSIT(com.binance.dex.api.client.domain.broadcast.TxType.SIDE_DEPOSIT),
+    MINT(com.binance.dex.api.client.domain.broadcast.TxType.MINT),
+    CREATE_VALIDATOR(com.binance.dex.api.client.domain.broadcast.TxType.CREATE_VALIDATOR),
+    REMOVE_VALIDATOR(com.binance.dex.api.client.domain.broadcast.TxType.REMOVE_VALIDATOR),
+    TIME_LOCK(com.binance.dex.api.client.domain.broadcast.TxType.TimeLock),
+    TIME_UNLOCK(com.binance.dex.api.client.domain.broadcast.TxType.TimeUnlock),
+    TIME_RELOCK(com.binance.dex.api.client.domain.broadcast.TxType.TimeRelock),
+    SET_ACCOUNT_FLAG(com.binance.dex.api.client.domain.broadcast.TxType.SetAccountFlag),
+    HTL_TRANSFER(com.binance.dex.api.client.domain.broadcast.TxType.HTL_TRANSFER),
+    DEPOSIT_HTL(com.binance.dex.api.client.domain.broadcast.TxType.DEPOSIT_HTL),
+    CLAIM_HTL(com.binance.dex.api.client.domain.broadcast.TxType.CLAIM_HTL),
+    REFUND_HTL(com.binance.dex.api.client.domain.broadcast.TxType.REFUND_HTL),
+    CREATE_SIDECHAIN_VALIDATOR(com.binance.dex.api.client.domain.broadcast.TxType.CREATE_SIDECHAIN_VALIDATOR),
+    EDIT_SIDECHAIN_VALIDATOR(com.binance.dex.api.client.domain.broadcast.TxType.EDIT_SIDECHAIN_VALIDATOR),
+    SIDECHAIN_DELEGATE(com.binance.dex.api.client.domain.broadcast.TxType.SIDECHAIN_DELEGATE),
+    SIDECHAIN_REDELEGATE(com.binance.dex.api.client.domain.broadcast.TxType.SIDECHAIN_REDELEGATE),
+    SIDECHAIN_UNDELEGATE(com.binance.dex.api.client.domain.broadcast.TxType.SIDECHAIN_UNBOND),
+    ORACLE_CLAIM(com.binance.dex.api.client.domain.broadcast.TxType.CLAIM),
+    CROSS_TRANSFER_OUT(com.binance.dex.api.client.domain.broadcast.TxType.TRANSFER_OUT),
+    CROSS_BIND(com.binance.dex.api.client.domain.broadcast.TxType.BIND),
+    CROSS_UNBIND(com.binance.dex.api.client.domain.broadcast.TxType.UNBIND),
+    BSC_SUBMIT_EVIDENCE(com.binance.dex.api.client.domain.broadcast.TxType.BSC_SUBMIT_EVIDENCE),
+    SIDECHAIN_UNJAIL(com.binance.dex.api.client.domain.broadcast.TxType.SIDECHAIN_UNJAIL),
+    TRANSFER_TOKEN_OWNERSHIP(com.binance.dex.api.client.domain.broadcast.TxType.TRANSFER_TOKEN_OWNERSHIP),
+    TINY_TOKEN_ISSUE(com.binance.dex.api.client.domain.broadcast.TxType.TINY_TOKEN_ISSUE),
+    MINI_TOKEN_ISSUE(com.binance.dex.api.client.domain.broadcast.TxType.MINI_TOKEN_ISSUE),
+    MINI_TOKEN_LIST(com.binance.dex.api.client.domain.broadcast.TxType.MINI_TOKEN_LIST),
+    MINI_TOKEN_SET_URI(com.binance.dex.api.client.domain.broadcast.TxType.MINI_TOKEN_SET_URI);
+
+    private com.binance.dex.api.client.domain.broadcast.TxType code;
+
+    TxType(com.binance.dex.api.client.domain.broadcast.TxType code) {
+        this.code = code;
+    }
+
+    private static final Map<String, com.binance.dex.api.client.domain.broadcast.TxType> nameTypeMap = new HashMap<>();
+
+    static {
+        for (TxType txType : TxType.values()) {
+            nameTypeMap.put(txType.name().toUpperCase(), txType.code);
+        }
+    }
+
+    public static com.binance.dex.api.client.domain.broadcast.TxType getTypeByName(String name) {
+        if (name == null) {
+            return null;
+        }
+        return nameTypeMap.get(name.toUpperCase());
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FBscSubmitEvidenceConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FBscSubmitEvidenceConverter.java
@@ -1,0 +1,27 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.domain.slash.BscSubmitEvidence;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+import java.util.Map;
+
+
+public class FBscSubmitEvidenceConverter extends TransactionConverter<BscSubmitEvidence> {
+
+    @Override
+    public TxType getType() {
+        return TxType.BSC_SUBMIT_EVIDENCE;
+    }
+
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        Map<String, Object> map = JsonUtil.fromJson(transactionV2.getData(), Map.class);
+        map.put("submitter", transactionV2.getFromAddr());
+        transaction.setData(JsonUtil.toJson(map));
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FBurnConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FBurnConverter.java
@@ -1,0 +1,22 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.Burn;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+
+public class FBurnConverter extends TransactionConverter<Burn> {
+
+    @Override
+    public TxType getType() {
+        return TxType.BURN;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FCancelOrderConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FCancelOrderConverter.java
@@ -1,0 +1,39 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.CancelOrder;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class FCancelOrderConverter extends TransactionConverter<CancelOrder> {
+
+    public TxType getType() {
+        return TxType.CANCEL_ORDER;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        Map<String, Object> map = JsonUtil.fromJson(transactionV2.getData(), Map.class);
+        String symbol = (String) map.get("symbol");
+        String orderId = (String) map.get("orderId");
+
+        Map<String, Object> newMap = new HashMap<>();
+        newMap.put("orderData", CO.builder().symbol(symbol).orderId(orderId).build());
+        transaction.setData(JsonUtil.toJson(newMap));
+    }
+}
+
+@Data
+@Builder
+class CO {
+    String symbol;
+    String orderId;
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FClaimHtlConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FClaimHtlConverter.java
@@ -1,0 +1,21 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.ClaimHashTimerLock;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+
+public class FClaimHtlConverter extends TransactionConverter<ClaimHashTimerLock> {
+
+    @Override
+    public TxType getType() {
+        return TxType.CLAIM_HTL;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setData(null);
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FCreateSideChainValidatorConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FCreateSideChainValidatorConverter.java
@@ -1,0 +1,22 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.domain.stake.sidechain.CreateSideChainValidator;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+
+public class FCreateSideChainValidatorConverter extends TransactionConverter<CreateSideChainValidator> {
+
+    @Override
+    public TxType getType() {
+        return TxType.CREATE_SIDECHAIN_VALIDATOR;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FCreateValidatorConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FCreateValidatorConverter.java
@@ -1,0 +1,23 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.CreateValidator;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+
+public class FCreateValidatorConverter extends TransactionConverter<CreateValidator> {
+
+    @Override
+    public TxType getType() {
+        return TxType.CREATE_VALIDATOR;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+        transaction.setData(transactionV2.getData());
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FCrossBindConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FCrossBindConverter.java
@@ -1,0 +1,33 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.bridge.Bind;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+import java.util.Map;
+
+
+public class FCrossBindConverter extends TransactionConverter<Bind> {
+
+    @Override
+    public TxType getType() {
+        return TxType.BIND;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+
+        Map<String, Object> map = JsonUtil.fromJson(transactionV2.getData(), Map.class);
+        map.put("symbol", transactionV2.getAsset());
+        map.put("from", transactionV2.getFromAddr());
+        map.put("amount", transactionV2.getAmount());
+
+        transaction.setData(JsonUtil.toJson(map));
+
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FCrossTransferOutConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FCrossTransferOutConverter.java
@@ -1,0 +1,36 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.bridge.TransferOut;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.Token;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+import java.util.Map;
+
+
+public class FCrossTransferOutConverter extends TransactionConverter<TransferOut> {
+
+    @Override
+    public TxType getType() {
+        return TxType.TRANSFER_OUT;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+
+        Map<String, Object> map = JsonUtil.fromJson(transactionV2.getData(), Map.class);
+        map.put("from", transactionV2.getFromAddr());
+        map.put("toAddress", transactionV2.getToAddr());
+
+        Token amount = Token.builder().denom(transactionV2.getAsset()).amount(transactionV2.getAmount()).build();
+        map.put("amount", amount);
+
+        transaction.setData(JsonUtil.toJson(map));
+    }
+
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FCrossUnBindConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FCrossUnBindConverter.java
@@ -1,0 +1,28 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.bridge.Unbind;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class FCrossUnBindConverter extends TransactionConverter<Unbind> {
+
+    @Override
+    public TxType getType() {
+        return TxType.UNBIND;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        Map<String, Object> newMap = new HashMap<>();
+        newMap.put("symbol", transactionV2.getAsset());
+        newMap.put("from", transactionV2.getFromAddr());
+        transaction.setData(JsonUtil.toJson(newMap));
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FDepositConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FDepositConverter.java
@@ -1,0 +1,24 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.Deposit;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+
+public class FDepositConverter extends TransactionConverter<Deposit> {
+
+    @Override
+    public TxType getType() {
+        return TxType.DEPOSIT;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+
+        transaction.setData(null);
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FDepositHtlConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FDepositHtlConverter.java
@@ -1,0 +1,24 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.DepositHashTimerLock;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+
+public class FDepositHtlConverter extends TransactionConverter<DepositHashTimerLock> {
+
+    @Override
+    public TxType getType() {
+        return TxType.DEPOSIT_HTL;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+
+        transaction.setData(null);
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FEditSideChainValidatorConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FEditSideChainValidatorConverter.java
@@ -1,0 +1,21 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.domain.stake.sidechain.EditSideChainValidator;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+
+public class FEditSideChainValidatorConverter extends TransactionConverter<EditSideChainValidator> {
+
+    @Override
+    public TxType getType() {
+        return TxType.EDIT_SIDECHAIN_VALIDATOR;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        return;
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FFreezeConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FFreezeConverter.java
@@ -1,0 +1,22 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.TokenFreeze;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+
+public class FFreezeConverter extends TransactionConverter<TokenFreeze> {
+
+    @Override
+    public TxType getType() {
+        return TxType.FREEZE_TOKEN;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FHtlTransferConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FHtlTransferConverter.java
@@ -1,0 +1,31 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.HashTimerLockTransfer;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+import java.util.Map;
+
+
+public class FHtlTransferConverter extends TransactionConverter<HashTimerLockTransfer> {
+
+    @Override
+    public TxType getType() {
+        return TxType.HTL_TRANSFER;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+        transaction.setToAddr(transactionV2.getToAddr());
+
+        Map<String, Object> map = JsonUtil.fromJson(transactionV2.getData(), Map.class);
+        map.put("from", transactionV2.getFromAddr());
+        map.put("to", transactionV2.getToAddr());
+        transaction.setData(JsonUtil.toJson(map));
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FIssueTokenConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FIssueTokenConverter.java
@@ -1,0 +1,28 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.Issue;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+import java.util.Map;
+
+
+public class FIssueTokenConverter extends TransactionConverter<Issue> {
+
+    @Override
+    public TxType getType() {
+        return TxType.ISSUE;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        Map<String, Object> map = JsonUtil.fromJson(transactionV2.getData(), Map.class);
+        Long totalSupply = (Long) map.get("totalSupply");
+        transaction.setValue(NumberUtil.longToBigDecimalString(totalSupply));
+        transaction.setData(null);
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FListingConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FListingConverter.java
@@ -1,0 +1,31 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.Listing;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+import java.util.Map;
+
+public class FListingConverter extends TransactionConverter<Listing> {
+
+    @Override
+    public TxType getType() {
+        return TxType.LISTING;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        Map<String, Object> map = JsonUtil.fromJson(transactionV2.getData(), Map.class);
+        Long initPrice = ((Number) map.get("initPrice")).longValue();
+        transaction.setValue(NumberUtil.longToBigDecimalString(initPrice));
+
+        String asset = (String) map.get("baseAsset");
+        transaction.setTxAsset(asset);
+
+        transaction.setData(null);
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FMiniTokenIssueConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FMiniTokenIssueConverter.java
@@ -1,0 +1,29 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.MiniTokenIssue;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+import java.util.Map;
+
+
+public class FMiniTokenIssueConverter extends TransactionConverter<MiniTokenIssue> {
+
+    @Override
+    public TxType getType() {
+        return TxType.MINI_TOKEN_ISSUE;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        Map<String, Object> map = JsonUtil.fromJson(transactionV2.getData(), Map.class);
+        Long totalSupply = (Long) map.get("totalSupply");
+        transaction.setValue(NumberUtil.longToBigDecimalString(totalSupply));
+
+        transaction.setData(null);
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FMiniTokenListingConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FMiniTokenListingConverter.java
@@ -1,0 +1,32 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.MiniTokenListing;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+import java.util.Map;
+
+
+public class FMiniTokenListingConverter extends TransactionConverter<MiniTokenListing> {
+
+    @Override
+    public TxType getType() {
+        return TxType.MINI_TOKEN_LIST;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        Map<String, Object> map = JsonUtil.fromJson(transactionV2.getData(), Map.class);
+        Long initPrice = ((Number) map.get("initPrice")).longValue();
+        transaction.setValue(NumberUtil.longToBigDecimalString(initPrice));
+
+        String asset = (String) map.get("baseAsset");
+        transaction.setTxAsset(asset);
+
+        transaction.setData(null);
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FMiniTokenSetURIConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FMiniTokenSetURIConverter.java
@@ -1,0 +1,21 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.MiniTokenSetURI;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+
+public class FMiniTokenSetURIConverter extends TransactionConverter<MiniTokenSetURI> {
+
+    @Override
+    public TxType getType() {
+        return TxType.MINI_TOKEN_SET_URI;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setData(null);
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FMintConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FMintConverter.java
@@ -1,0 +1,24 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.Mint;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+
+public class FMintConverter extends TransactionConverter<Mint> {
+
+    @Override
+    public TxType getType() {
+        return TxType.MINT;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+        transaction.setData(null);
+    }
+}
+

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FNewOrderConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FNewOrderConverter.java
@@ -1,0 +1,61 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.NewOrder;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class FNewOrderConverter extends TransactionConverter<NewOrder> {
+
+    public TxType getType() {
+        return TxType.NEW_ORDER;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        Map<String, Object> map = JsonUtil.fromJson(transactionV2.getData(), Map.class);
+        String symbol = (String) map.get("symbol");
+        String orderId = (String) map.get("orderId");
+        String orderType = (String) map.get("orderType");
+        String side = (String) map.get("side");
+        String timeInForce = (String) map.get("timeInForce");
+        String price = (String) map.get("price");
+        String quantity = (String) map.get("quantity");
+
+        transaction.setOrderId(orderId);
+        transaction.setTxAsset(symbol.split("_")[0]);
+
+        Map<String, Object> newMap = new HashMap<>();
+        newMap.put("orderData", NO.builder().symbol(symbol).orderId(orderId)
+                .orderType(orderType).side(side).timeInForce(timeInForce)
+                .price(NumberUtil.longToBigDecimal(Long.parseLong(price)).stripTrailingZeros().toPlainString())
+                .quantity(NumberUtil.longToBigDecimal(Long.parseLong(quantity)).stripTrailingZeros().toPlainString())
+                .build());
+        transaction.setData(JsonUtil.toJson(newMap));
+
+        BigDecimal value = NumberUtil.longToBigDecimal(Long.parseLong(price)).multiply(NumberUtil.longToBigDecimal(Long.parseLong(quantity)).setScale(8, BigDecimal.ROUND_HALF_UP));
+        transaction.setValue(NumberUtil.decimalFormat(value));
+    }
+}
+
+@Data
+@Builder
+class NO {
+    String symbol;
+    String orderId;
+    String orderType;
+    String side;
+    String price;
+    String quantity;
+    String timeInForce;
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FOracleClaimConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FOracleClaimConverter.java
@@ -1,0 +1,21 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.domain.oracle.ClaimMsg;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+
+public class FOracleClaimConverter extends TransactionConverter<ClaimMsg> {
+
+    @Override
+    public TxType getType() {
+        return TxType.CLAIM;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setData(transactionV2.getData());
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FProposalConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FProposalConverter.java
@@ -1,0 +1,33 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.SubmitProposal;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+import java.util.Map;
+
+
+public class FProposalConverter extends TransactionConverter<SubmitProposal> {
+
+    @Override
+    public TxType getType() {
+        return TxType.SUBMIT_PROPOSAL;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+
+        Map<String, Object> map = JsonUtil.fromJson(transactionV2.getData(), Map.class);
+
+        map.remove("proposalId");
+        map.remove("baseAssetSymbol");
+        map.remove("quoteAssetSymbol");
+        transaction.setData(JsonUtil.toJson(map));
+
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FRefundHtlConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FRefundHtlConverter.java
@@ -1,0 +1,21 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.RefundHashTimerLock;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+
+public class FRefundHtlConverter extends TransactionConverter<RefundHashTimerLock> {
+
+    @Override
+    public TxType getType() {
+        return TxType.REFUND_HTL;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setData(null);
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FRemoveValidatorConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FRemoveValidatorConverter.java
@@ -1,0 +1,21 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.RemoveValidator;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+
+public class FRemoveValidatorConverter extends TransactionConverter<RemoveValidator> {
+
+    @Override
+    public TxType getType() {
+        return TxType.REMOVE_VALIDATOR;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setData(null);
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FSetAccountFlagsConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FSetAccountFlagsConverter.java
@@ -1,0 +1,31 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.SetAccountFlag;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class FSetAccountFlagsConverter extends TransactionConverter<SetAccountFlag> {
+
+    @Override
+    public TxType getType() {
+        return TxType.SetAccountFlag;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        Map<String, Object> map = JsonUtil.fromJson(transactionV2.getData(), Map.class);
+        Long flags = ((Number) map.get("flags")).longValue();
+
+        Map<String, Object> newMap = new HashMap<>();
+        newMap.put("fromAddr", transactionV2.getFromAddr());
+        newMap.put("flags", flags);
+        transaction.setData(JsonUtil.toJson(newMap));
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FSideChainDelegateConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FSideChainDelegateConverter.java
@@ -1,0 +1,39 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.domain.stake.sidechain.SideChainDelegate;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.Token;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+import java.util.Map;
+
+
+public class FSideChainDelegateConverter extends TransactionConverter<SideChainDelegate> {
+
+    @Override
+    public TxType getType() {
+        return TxType.SIDECHAIN_DELEGATE;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+
+        Map<String, Object> map = JsonUtil.fromJson(transactionV2.getData(), Map.class);
+        if (transaction.getValue() == null || transaction.getTxAsset() == null) {
+            Token token = getToken(map, "amount");
+            transaction.setTxAsset(token.getDenom());
+            transaction.setValue(NumberUtil.longToBigDecimalString(token.getAmount()));
+        }
+
+        map.put("delegatorAddress", map.get("delegatorAddr"));
+        map.put("validatorAddress", map.get("validatorAddr"));
+        map.remove("delegatorAddr");
+        map.remove("validatorAddr");
+        transaction.setData(JsonUtil.toJson(map));
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FSideChainRedelegateConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FSideChainRedelegateConverter.java
@@ -1,0 +1,32 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.domain.stake.sidechain.SideChainRedelegate;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.Token;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+import java.util.Map;
+
+public class FSideChainRedelegateConverter extends TransactionConverter<SideChainRedelegate> {
+
+    @Override
+    public TxType getType() {
+        return TxType.SIDECHAIN_REDELEGATE;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+
+        Map<String, Object> map = JsonUtil.fromJson(transactionV2.getData(), Map.class);
+        if (transaction.getValue() == null || transaction.getTxAsset() == null) {
+            Token token = getToken(map, "amount");
+            transaction.setTxAsset(token.getDenom());
+            transaction.setValue(NumberUtil.longToBigDecimalString(token.getAmount()));
+        }
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FSideChainUnJailConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FSideChainUnJailConverter.java
@@ -1,0 +1,21 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.domain.slash.SideChainUnJail;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+
+public class FSideChainUnJailConverter extends TransactionConverter<SideChainUnJail> {
+
+    @Override
+    public TxType getType() {
+        return TxType.SIDECHAIN_UNJAIL;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        return;
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FSideChainUndelegateConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FSideChainUndelegateConverter.java
@@ -1,0 +1,39 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.domain.stake.sidechain.SideChainUnBond;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.Token;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+import java.util.Map;
+
+
+public class FSideChainUndelegateConverter extends TransactionConverter<SideChainUnBond> {
+
+    @Override
+    public TxType getType() {
+        return TxType.SIDECHAIN_UNBOND;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+
+        Map<String, Object> map = JsonUtil.fromJson(transactionV2.getData(), Map.class);
+        if (transaction.getValue() == null || transaction.getTxAsset() == null) {
+            Token token = getToken(map, "amount");
+            transaction.setTxAsset(token.getDenom());
+            transaction.setValue(NumberUtil.longToBigDecimalString(token.getAmount()));
+        }
+
+        map.put("delegatorAddress", map.get("delegatorAddr"));
+        map.put("validatorAddress", map.get("validatorAddr"));
+        map.remove("delegatorAddr");
+        map.remove("validatorAddr");
+        transaction.setData(JsonUtil.toJson(map));
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FSideDepositConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FSideDepositConverter.java
@@ -1,0 +1,21 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.SideDeposit;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+public class FSideDepositConverter extends TransactionConverter<SideDeposit> {
+
+    @Override
+    public TxType getType() {
+        return TxType.SIDE_DEPOSIT;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FSideProposalConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FSideProposalConverter.java
@@ -1,0 +1,32 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.SideSubmitProposal;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+import java.util.Map;
+
+
+public class FSideProposalConverter extends TransactionConverter<SideSubmitProposal> {
+
+    @Override
+    public TxType getType() {
+        return TxType.SIDE_SUBMIT_PROPOSAL;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+
+        Map<String, Object> map = JsonUtil.fromJson(transactionV2.getData(), Map.class);
+
+        map.remove("proposalId");
+        map.remove("baseAssetSymbol");
+        map.remove("quoteAssetSymbol");
+        transaction.setData(JsonUtil.toJson(map));
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FSideVoteConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FSideVoteConverter.java
@@ -1,0 +1,23 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.SideVote;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+import lombok.extern.slf4j.Slf4j;
+
+
+@Slf4j
+public class FSideVoteConverter extends TransactionConverter<SideVote> {
+
+    @Override
+    public TxType getType() {
+        return TxType.SIDE_VOTE;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        return;
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FTimeLockConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FTimeLockConverter.java
@@ -1,0 +1,30 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.TimeLock;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+import java.util.Map;
+
+
+public class FTimeLockConverter extends TransactionConverter<TimeLock> {
+
+    @Override
+    public TxType getType() {
+        return TxType.TimeLock;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+
+        Map<String, Object> map = JsonUtil.fromJson(transactionV2.getData(), Map.class);
+
+        map.remove("amount");
+        transaction.setData(JsonUtil.toJson(map));
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FTimeReLockConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FTimeReLockConverter.java
@@ -1,0 +1,30 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.TimeRelock;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+import java.util.Map;
+
+
+public class FTimeReLockConverter extends TransactionConverter<TimeRelock> {
+
+    @Override
+    public TxType getType() {
+        return TxType.TimeRelock;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+
+        Map<String, Object> map = JsonUtil.fromJson(transactionV2.getData(), Map.class);
+
+        map.remove("amount");
+        transaction.setData(JsonUtil.toJson(map));
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FTimeUnlockConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FTimeUnlockConverter.java
@@ -1,0 +1,21 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.TimeUnlock;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+
+public class FTimeUnlockConverter extends TransactionConverter<TimeUnlock> {
+
+    @Override
+    public TxType getType() {
+        return TxType.TimeUnlock;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        return;
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FTinyTokenIssueConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FTinyTokenIssueConverter.java
@@ -1,0 +1,29 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.TinyTokenIssue;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+import java.util.Map;
+
+
+public class FTinyTokenIssueConverter extends TransactionConverter<TinyTokenIssue> {
+
+    @Override
+    public TxType getType() {
+        return TxType.TINY_TOKEN_ISSUE;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        Map<String, Object> map = JsonUtil.fromJson(transactionV2.getData(), Map.class);
+        Long totalSupply = (Long) map.get("totalSupply");
+        transaction.setValue(NumberUtil.longToBigDecimalString(totalSupply));
+
+        transaction.setData(null);
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FTransferConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FTransferConverter.java
@@ -1,0 +1,24 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.Transfer;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+
+public class FTransferConverter extends TransactionConverter<Transfer> {
+
+    public TxType getType() {
+        return TxType.TRANSFER;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        if (transactionV2.getAmount() != null) {
+            transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+        }
+        transaction.setToAddr(transactionV2.getToAddr());
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FTransferOwnershipConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FTransferOwnershipConverter.java
@@ -1,0 +1,31 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.TransferTokenOwnership;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.JsonUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class FTransferOwnershipConverter extends TransactionConverter<TransferTokenOwnership> {
+
+    @Override
+    public TxType getType() {
+        return TxType.TRANSFER_TOKEN_OWNERSHIP;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("from", transactionV2.getFromAddr());
+        map.put("newOwner", transactionV2.getToAddr());
+        map.put("symbol", transactionV2.getAsset());
+
+        transaction.setData(JsonUtil.toJson(map));
+    }
+}
+

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FUnfreezeConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FUnfreezeConverter.java
@@ -1,0 +1,22 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.TokenUnfreeze;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.utils.converter.NumberUtil;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+
+
+public class FUnfreezeConverter extends TransactionConverter<TokenUnfreeze> {
+
+    @Override
+    public TxType getType() {
+        return TxType.UNFREEZE_TOKEN;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        transaction.setValue(NumberUtil.longToBigDecimalString(transactionV2.getAmount()));
+    }
+}

--- a/src/main/java/com/binance/dex/api/client/utils/converter/impl/FVoteConverter.java
+++ b/src/main/java/com/binance/dex/api/client/utils/converter/impl/FVoteConverter.java
@@ -1,0 +1,23 @@
+package com.binance.dex.api.client.utils.converter.impl;
+
+import com.binance.dex.api.client.domain.Transaction;
+import com.binance.dex.api.client.domain.TransactionV2;
+import com.binance.dex.api.client.domain.broadcast.TxType;
+import com.binance.dex.api.client.domain.broadcast.Vote;
+import com.binance.dex.api.client.utils.converter.TransactionConverter;
+import lombok.extern.slf4j.Slf4j;
+
+
+@Slf4j
+public class FVoteConverter extends TransactionConverter<Vote> {
+
+    @Override
+    public TxType getType() {
+        return TxType.VOTE;
+    }
+
+    @Override
+    public void doConvert(TransactionV2 transactionV2, Transaction transaction) {
+        return;
+    }
+}

--- a/src/test/java/com/binance/dex/api/client/examples/TransactionExample.java
+++ b/src/test/java/com/binance/dex/api/client/examples/TransactionExample.java
@@ -1,0 +1,40 @@
+package com.binance.dex.api.client.examples;
+
+import com.binance.dex.api.client.BinanceDexApiClientFactory;
+import com.binance.dex.api.client.BinanceDexApiRestClient;
+import com.binance.dex.api.client.BinanceDexEnvironment;
+import com.binance.dex.api.client.domain.*;
+import com.binance.dex.api.client.domain.request.TransactionsRequest;
+import com.binance.dex.api.client.utils.converter.TransactionConverterFactory;
+
+public class TransactionExample {
+    public static void main(String[] args) {
+        BinanceDexApiRestClient client =
+                BinanceDexApiClientFactory.newInstance().newRestClient(BinanceDexEnvironment.TEST_NET.getBaseUrl());
+
+        //Get transactions in last 24 hours
+        TransactionPageV2 transactions = client.getTransactions("tbnb135mqtf9gef879nmjlpwz6u2fzqcw4qlzrqwgvw");
+        System.out.println(transactions);
+
+        //Get transactions by criteria
+        TransactionsRequest request = new TransactionsRequest();
+        request.setStartTime(1629272621945L);
+        request.setEndTime(1629359021945L);
+        request.setType("ORACLE_CLAIM");
+        request.setAddress("tbnb135mqtf9gef879nmjlpwz6u2fzqcw4qlzrqwgvw");
+        request.setAddressType("FROM");
+        request.setOffset(5);
+        request.setLimit(1);
+        transactions = client.getTransactions(request);
+        System.out.println(transactions);
+
+        //Get transaction a block
+        transactions = client.getTransactionsInBlock(15759101);
+        System.out.println(transactions);
+
+        //Convert transaction to previous models
+        TransactionConverterFactory converterFactory = new TransactionConverterFactory();
+        TransactionPage transactionPage = converterFactory.convert(transactions);
+        System.out.println(transactionPage);
+    }
+}

--- a/src/test/java/com/binance/dex/api/client/examples/TransactionExample.java
+++ b/src/test/java/com/binance/dex/api/client/examples/TransactionExample.java
@@ -3,7 +3,8 @@ package com.binance.dex.api.client.examples;
 import com.binance.dex.api.client.BinanceDexApiClientFactory;
 import com.binance.dex.api.client.BinanceDexApiRestClient;
 import com.binance.dex.api.client.BinanceDexEnvironment;
-import com.binance.dex.api.client.domain.*;
+import com.binance.dex.api.client.domain.TransactionPage;
+import com.binance.dex.api.client.domain.TransactionPageV2;
 import com.binance.dex.api.client.domain.request.TransactionsRequest;
 import com.binance.dex.api.client.utils.converter.TransactionConverterFactory;
 
@@ -17,6 +18,7 @@ public class TransactionExample {
         System.out.println(transactions);
 
         //Get transactions by criteria
+        //Refer to this for more: https://docs.binance.org/api-reference/dex-api/block-service.html#apiv1txs
         TransactionsRequest request = new TransactionsRequest();
         request.setStartTime(1629272621945L);
         request.setEndTime(1629359021945L);

--- a/src/test/java/com/binance/dex/api/client/examples/TransactionExampleAsync.java
+++ b/src/test/java/com/binance/dex/api/client/examples/TransactionExampleAsync.java
@@ -16,6 +16,7 @@ public class TransactionExampleAsync {
         client.getTransactions("tbnb135mqtf9gef879nmjlpwz6u2fzqcw4qlzrqwgvw", response -> System.out.println(response));
 
         //Get transactions by criteria
+        //Refer to this for more: https://docs.binance.org/api-reference/dex-api/block-service.html#apiv1txs
         TransactionsRequest request = new TransactionsRequest();
         request.setStartTime(1629272621945L);
         request.setEndTime(1629359021945L);

--- a/src/test/java/com/binance/dex/api/client/examples/TransactionExampleAsync.java
+++ b/src/test/java/com/binance/dex/api/client/examples/TransactionExampleAsync.java
@@ -1,0 +1,32 @@
+package com.binance.dex.api.client.examples;
+
+import com.binance.dex.api.client.BinanceDexApiAsyncRestClient;
+import com.binance.dex.api.client.BinanceDexApiClientFactory;
+import com.binance.dex.api.client.BinanceDexApiRestClient;
+import com.binance.dex.api.client.BinanceDexEnvironment;
+import com.binance.dex.api.client.domain.TransactionPageV2;
+import com.binance.dex.api.client.domain.request.TransactionsRequest;
+
+public class TransactionExampleAsync {
+    public static void main(String[] args) {
+        BinanceDexApiAsyncRestClient client =
+                BinanceDexApiClientFactory.newInstance().newAsyncRestClient(BinanceDexEnvironment.TEST_NET.getBaseUrl());
+
+        //Get transactions in last 24 hours
+        client.getTransactions("tbnb135mqtf9gef879nmjlpwz6u2fzqcw4qlzrqwgvw", response -> System.out.println(response));
+
+        //Get transactions by criteria
+        TransactionsRequest request = new TransactionsRequest();
+        request.setStartTime(1629272621945L);
+        request.setEndTime(1629359021945L);
+        request.setType("ORACLE_CLAIM");
+        request.setAddress("tbnb135mqtf9gef879nmjlpwz6u2fzqcw4qlzrqwgvw");
+        request.setAddressType("FROM");
+        request.setOffset(5);
+        request.setLimit(1);
+        client.getTransactions(request, response -> System.out.println(response));
+
+        //Get transaction a block
+        client.getTransactionsInBlock(15759101, response -> System.out.println(response));
+    }
+}


### PR DESCRIPTION
Breaking Changes
* getTransactions(TransactionsRequest request) will return transactions with new data model TransactionPageV2
* getTransactions(String address) will return transactions for an address in last 24 hours with new data model TransactionPageV2

Please refer to TransactionConverterFactory.java to see the mappings of the fields between TransactionPageV2 and TransactionPage 

Please refer to TransactionExample.java and [API Doc](https://docs.binance.org/api-reference/dex-api/block-service.html) for more details, the underlying API [Migration Guide](https://github.com/binance-chain/docs-site/blob/block-service/docs/api-reference/dex-api/migration-guide.md) could be also useful 

New API
* getTransactionsInBlock(long blockHeight) will return transaction in a specific block. 

